### PR TITLE
Updated bib file with published papers that were previously cited as …

### DIFF
--- a/tradeagreements.bib
+++ b/tradeagreements.bib
@@ -161,12 +161,14 @@
     pages   = "35--48"
 }
 
-@article{bb,
+@article{beshkar2017cap,
     author  = "Mostafa Beshkar and Eric W. Bond",
     title   = "Cap and Escape in Trade Agreements",
-    note = "Available at \url{https://www.aeaweb.org/articles?id=10.1257/mic.20160218&&from=f}",
-    year    = "Forthcoming",
-		journal = "American Economic Journal -- Microeconomics",
+    year    = "2017",
+	journal = "American Economic Journal: Microeconomics",
+    volume  = "9",
+    number  = "4",
+    pages   = "171--202"
 }
 
 @article{bbr,
@@ -260,11 +262,13 @@
     pages   = "21--43"
 }
 
-@unpublished{buzard2013a,
+@article{buzard2017self,
     author  = "Kristy Buzard",
     title   = "Self-enforcing Trade Agreements and Lobbying",
-    note = "Available at \url{https://kbuzard.expressions.syr.edu/wp-content/uploads/Self-enforcing-Trade_Agreements.pdf}",
-    year    = "2016"
+    year    = "2017",
+    journal = "Journal of International Economics",
+    volume  = "108",
+    pages   = "226--242"
 }
 
 @unpublished{buzard2014,
@@ -284,11 +288,13 @@
     pages   = "1--29"
 }
 
-@unpublished{clz,
+@article{cole2021contesting,
     author  = "Matthew T. Cole and James Lake and Ben Zissimos",
     title   = "Contesting an International Trade Agreement",
-    note = "Available at \url{http://people.smu.edu/jlake/pdfs/TAcontest.pdf}",
-    year    = "2017"
+    year    = "2021",
+    journal = "Journal of International Economics",
+    volume  = "128",
+    pages   = "103410"
 }
 
 
@@ -583,11 +589,14 @@
     pages   = "109--143"
 }
 
-@article{ms2013,
+@article{maggi2018trade,
     author  = "Giovanni Maggi and Robert W. Staiger",
     title   = "Trade Disputes and Settlement",
-    note = "Available at \url{http://www.dartmouth.edu/~rstaiger/TradeDisputes_022215.pdf}",
-    year    = "2015"
+    year    = "2018",
+    journal  = "International Economic Review",
+    volume  = "59",
+    number  = "1",
+    pages   = "19--50"
 }
 
 @article{martinvergote,


### PR DESCRIPTION
…working papers

Updated bib file with published papers that were previously cited as working papers.

These include:

Beshkar, Mostafa and Eric W. Bond (2017), “Cap and Escape in Trade Agreements,”

Buzard, Kristy (2017), “Self-enforcing Trade Agreements and Lobbying”

Cole, Matthew T., James Lake, and Ben Zissimos (2021), “Contesting an International Trade Agreement,”

Maggi, Giovanni and Robert W. Staiger (2018), “Trade Disputes and Settlement,”